### PR TITLE
Replacing errors with warnings when downloading logs and reports

### DIFF
--- a/vib-action/src/main.ts
+++ b/vib-action/src/main.ts
@@ -173,6 +173,7 @@ export function displayExecutionGraph(
   for (const task of executionGraph['tasks']) {
     const taskId = task['task_id']
     let taskName = task['action_id']
+    const taskError = task['error']
     const taskStatus = task['status']
     const recordedStatus = recordedStatuses[taskId]
 
@@ -190,7 +191,7 @@ export function displayExecutionGraph(
       core.info(`Task ${taskName} is now in status ${taskStatus}`)
       switch(taskStatus) {
         case 'FAILED': 
-          core.error(`Task ${taskName} has failed`)
+          core.error(`Task ${taskName} has failed. Error: ${taskError}`)
           break
         case 'SKIPPED':
           core.warning(`Task ${taskName} has been skipped`)

--- a/vib-action/src/main.ts
+++ b/vib-action/src/main.ts
@@ -514,7 +514,7 @@ export async function getRawReports(
   } catch (err) {
     if (axios.isAxiosError(err) && err.response) {
       // Don't throw error if we cannot fetch a report
-      core.error(`Received error while fetching reports for task ${taskId}. Error code: ${err.response.status}. Message: ${err.response.statusText}`)
+      core.warning(`Received error while fetching reports for task ${taskId}. Error code: ${err.response.status}. Message: ${err.response.statusText}`)
       return []
     } else {
       throw err
@@ -547,7 +547,7 @@ export async function getRawLogs(
   } catch (err) {
     if (axios.isAxiosError(err) && err.response) {
       // Don't throw error if we cannot fetch a log
-      core.error(`Received error while fetching logs for task ${taskId}. Error code: ${err.response.status}. Message: ${err.response.statusText}`)
+      core.warning(`Received error while fetching logs for task ${taskId}. Error code: ${err.response.status}. Message: ${err.response.statusText}`)
       return null
     } else {
       throw err


### PR DESCRIPTION
Replacing errors with warnings when downloading logs and reports

```
closes #6 
```